### PR TITLE
Don’t die with include method inside a block

### DIFF
--- a/duchain/builders/usebuilder.cpp
+++ b/duchain/builders/usebuilder.cpp
@@ -87,7 +87,14 @@ void UseBuilder::visitMixin(Ast *node, bool include)
         const DeclarationPointer d = ev.lastDeclaration();
         if (d) {
             UseBuilderBase::newUse(m_editor->findRange(n), d);
-            ev.setContext(d->internalContext());
+            // TODO: is this context useful for something actually? If it is, I guess we need to create it.
+            auto context = d->internalContext();
+            // Setting invalid context doesn’t make sense and just causes fail in helpers.cpp’s context assert
+            // TODO: maybe visitClassName() & co. needs this too?
+            if(context) {
+                Q_ASSERT(context);
+                ev.setContext(context);
+            }
         } else {
             break;
         }

--- a/duchain/tests/duchain.cpp
+++ b/duchain/tests/duchain.cpp
@@ -28,6 +28,8 @@
 #include <language/duchain/duchainutils.h>
 #include <language/duchain/problem.h>
 
+#include <language/interfaces/iastcontainer.h>
+
 // Ruby
 #include <duchain/tests/duchain.h>
 #include <duchain/helpers.h>
@@ -1827,6 +1829,25 @@ void TestDUChain::problemOnInvalidMixin()
     QStringList list;
     list << "TypeError: wrong argument type (expected Module)";
     testProblems(top, list);
+}
+
+/**
+ * Test that rspec’s expectation “include” is handled as normal expectation function and not as a module inclusion.
+ */
+void TestDUChain::rspecIncludeIsNormalFunction() {
+    QByteArray code("Then(\"nyaw\") { |string| expect.to include string }");
+    TopDUContext *top = parse(code, "rspecIncludeIsNormalFunction");
+    QVERIFY(top);
+    DUChainReleaser releaser(top);
+    DUChainWriteLocker lock;
+
+    KDevelop::DUContext *childContext = top->childContexts().first();
+    KDevelop::Declaration *declaration = childContext->localDeclarations().first();
+    qDebug() << declaration->comment();
+
+    Declaration *dec1 = top->localDeclarations().at(0);
+    QVERIFY(dec1->type<StructureType>());
+    QCOMPARE(dec1->type<StructureType>()->qualifiedIdentifier(), QualifiedIdentifier("Fixnum"));
 }
 
 //END: Include & Extend

--- a/duchain/tests/duchain.h
+++ b/duchain/tests/duchain.h
@@ -166,6 +166,7 @@ private slots:
     void include2();
     void extend();
     void problemOnInvalidMixin();
+    void rspecIncludeIsNormalFunction();
 };
 
 }


### PR DESCRIPTION
There is a crash that occurs at least with Cucumber tests in a code like 

```
Then("{string}") do |string|
  expect(foo).to include string
end
```

that is caused by kdev-ruby to recognize include function as a mixin insert rather than a method.

This commit makes the crash disappear, but I don’t know kdev-ruby (nor kdevplatform’s API) well, so there may be some better solution to this problem. Please say if there is something I should do differently.